### PR TITLE
fix compile error when SDL is not available

### DIFF
--- a/AppCUI/src/Terminal/Factory/Unix.cpp
+++ b/AppCUI/src/Terminal/Factory/Unix.cpp
@@ -4,16 +4,10 @@ using namespace AppCUI::Internal;
 
 #ifdef HAVE_SDL
 #    include "Terminal/SDLTerminal/SDLTerminal.hpp"
-constexpr bool have_sdl = true;
-#else
-constexpr bool have_sdl    = false;
 #endif
 
 #ifdef HAVE_CURSES
 #    include "Terminal/NcursesTerminal/NcursesTerminal.hpp"
-constexpr bool have_curses = true;
-#else
-constexpr bool have_curses = false;
 #endif
 
 std::unique_ptr<AbstractTerminal> AppCUI::Internal::GetTerminal(const InitializationData& initData)
@@ -24,30 +18,24 @@ std::unique_ptr<AbstractTerminal> AppCUI::Internal::GetTerminal(const Initializa
     {
     case TerminalType::Default:
     case TerminalType::SDL:
-        if (have_sdl)
-        {
-            term = std::make_unique<SDLTerminal>();
-        }
-        else
-        {
-            RETURNERROR(
-                  nullptr,
-                  "Unsuported terminal type for UNIX OS (%d): Please install SDL2",
-                  (unsigned int) initData.FrontEnd);
-        }
+#ifdef HAVE_SDL
+        term = std::make_unique<SDLTerminal>();
+#else
+        RETURNERROR(
+              nullptr,
+              "Unsuported terminal type for UNIX OS (%d): Please install SDL2",
+              (unsigned int) initData.FrontEnd);
+#endif
         break;
     case TerminalType::Terminal:
-        if (have_curses)
-        {
-            term = std::make_unique<NcursesTerminal>();
-        }
-        else
-        {
-            RETURNERROR(
-                  nullptr,
-                  "Unsuported terminal type for UNIX OS (%d): Please install ncurses",
-                  (unsigned int) initData.FrontEnd);
-        }
+#ifdef HAVE_CURSES
+        term = std::make_unique<NcursesTerminal>();
+#else
+        RETURNERROR(
+              nullptr,
+              "Unsuported terminal type for UNIX OS (%d): Please install ncurses",
+              (unsigned int) initData.FrontEnd);
+#endif
         break;
     default:
         RETURNERROR(nullptr, "Unsuported terminal type for UNIX OS (%d)", (unsigned int) initData.FrontEnd);


### PR DESCRIPTION
Note that when using constexpr, the code inside each if branch still has to compile, regardless of the value of the constexpr.
In the case where CMake would not find SDL, the compiler would not find the declaration of SDLTerminal, since the header where it is declared is not included.